### PR TITLE
Make hotkey prefix key a variable in Dolphin-SA controls.

### DIFF
--- a/docs/devices/ayn/loki-max.md
+++ b/docs/devices/ayn/loki-max.md
@@ -29,6 +29,7 @@
 
 {%include 'controls/retroarch.md' %}
 {%include 'controls/mednafen.md' %}
+{%set btn_prefix = 'SELECT' %}
 {%include 'controls/dolphin.md' %}
 {%include 'controls/mupen64plus.md' %}
 

--- a/docs/devices/ayn/loki-zero.md
+++ b/docs/devices/ayn/loki-zero.md
@@ -29,6 +29,7 @@
 
 {%include 'controls/retroarch.md' %}
 {%include 'controls/mednafen.md' %}
+{%set btn_prefix = 'SELECT' %}
 {%include 'controls/dolphin.md' %}
 {%include 'controls/mupen64plus.md' %}
 

--- a/includes/controls/dolphin.md
+++ b/includes/controls/dolphin.md
@@ -2,14 +2,14 @@
 
 | Button Combo | Action |
 | -- | -- |
-| ++"SELECT"+"START"++ | Quit Game |
-| ++"SELECT"+"R1"++ | Save State |
-| ++"SELECT"+"L1"++ | Load State |
-| ++"SELECT"+"{{ btn_south }}"++ | Screenshot |
-| ++"SELECT"+"{{ btn_east }}"++ | Change Internal Resolution |
-| ++"SELECT"+"{{ btn_north }}"++ | Change Aspect Ratio |
-| ++"SELECT"+"{{ btn_west }}"++ | Show FPS |
-| ++"SELECT"+"D-Pad Up"++ | Increase current state slot |
-| ++"SELECT"+"D-Pad Down"++ | Decrease current state slot |
-| ++"SELECT"+"R2"++ | Fast-Forward |
+| ++"{{ btn_prefix }}"+"START"++ | Quit Game |
+| ++"{{ btn_prefix }}"+"R1"++ | Save State |
+| ++"{{ btn_prefix }}"+"L1"++ | Load State |
+| ++"{{ btn_prefix }}"+"{{ btn_south }}"++ | Screenshot |
+| ++"{{ btn_prefix }}"+"{{ btn_east }}"++ | Change Internal Resolution |
+| ++"{{ btn_prefix }}"+"{{ btn_north }}"++ | Change Aspect Ratio |
+| ++"{{ btn_prefix }}"+"{{ btn_west }}"++ | Show FPS |
+| ++"{{ btn_prefix }}"+"D-Pad Up"++ | Increase current state slot |
+| ++"{{ btn_prefix }}"+"D-Pad Down"++ | Decrease current state slot |
+| ++"{{ btn_prefix }}"+"R2"++ | Fast-Forward |
 

--- a/includes/controls/dolphin.md
+++ b/includes/controls/dolphin.md
@@ -6,9 +6,9 @@
 | ++"{{ btn_prefix }}"+"R1"++ | Save State |
 | ++"{{ btn_prefix }}"+"L1"++ | Load State |
 | ++"{{ btn_prefix }}"+"{{ btn_south }}"++ | Screenshot |
-| ++"{{ btn_prefix }}"+"{{ btn_east }}"++ | Change Internal Resolution |
-| ++"{{ btn_prefix }}"+"{{ btn_north }}"++ | Change Aspect Ratio |
-| ++"{{ btn_prefix }}"+"{{ btn_west }}"++ | Show FPS |
+| ++"{{ btn_prefix }}"+"{{ btn_west }}"++ | Change Internal Resolution |
+| ++"{{ btn_prefix }}"+"{{ btn_east }}"++ | Change Aspect Ratio |
+| ++"{{ btn_prefix }}"+"{{ btn_north }}"++ | Show FPS |
 | ++"{{ btn_prefix }}"+"D-Pad Up"++ | Increase current state slot |
 | ++"{{ btn_prefix }}"+"D-Pad Down"++ | Decrease current state slot |
 | ++"{{ btn_prefix }}"+"R2"++ | Fast-Forward |


### PR DESCRIPTION
At least on S922X devices the hotkey prefix for Dolphin-SA differs from other devices so made it a vaiable in the controls docs.
**FIXME**:
It's currently also included in the AYN device docs, I assumed SELECT, but that needs to be checked.